### PR TITLE
Fixed Cedar Async for working with Asynchornous operations that are using dispatch_after 

### DIFF
--- a/CedarAsync.xcodeproj/project.pbxproj
+++ b/CedarAsync.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		96D6ECEB16333A1E00F26774 /* TimeoutSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 96D6ECEA16333A1E00F26774 /* TimeoutSpec.mm */; };
 		96D6ECEF1633415E00F26774 /* Timing.mm in Sources */ = {isa = PBXBuildFile; fileRef = 96D6ECEE1633415E00F26774 /* Timing.mm */; };
 		96D6ECF01633415E00F26774 /* Timing.mm in Sources */ = {isa = PBXBuildFile; fileRef = 96D6ECEE1633415E00F26774 /* Timing.mm */; };
+		E498D26B16F771D100D22636 /* GCDAsyncAction.mm in Sources */ = {isa = PBXBuildFile; fileRef = E498D26A16F771D100D22636 /* GCDAsyncAction.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +96,8 @@
 		96D6ECEA16333A1E00F26774 /* TimeoutSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TimeoutSpec.mm; sourceTree = "<group>"; };
 		96D6ECEE1633415E00F26774 /* Timing.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Timing.mm; sourceTree = "<group>"; };
 		96FF918F163642EB0003A779 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
+		E498D26916F771D000D22636 /* GCDAsyncAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDAsyncAction.h; sourceTree = "<group>"; };
+		E498D26A16F771D100D22636 /* GCDAsyncAction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GCDAsyncAction.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -237,6 +240,8 @@
 				96D6ECBA1633251500F26774 /* ExpectCallLength.mm */,
 				96D6ECBB1633251500F26774 /* ExpectFailureWithMessage.h */,
 				96D6ECBC1633251500F26774 /* ExpectFailureWithMessage.m */,
+				E498D26916F771D000D22636 /* GCDAsyncAction.h */,
+				E498D26A16F771D100D22636 /* GCDAsyncAction.mm */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -378,6 +383,7 @@
 				96D6ECE91633347C00F26774 /* HTTPClient.m in Sources */,
 				96D6ECEB16333A1E00F26774 /* TimeoutSpec.mm in Sources */,
 				96855A12163410EF0031533F /* PollingSpec.mm in Sources */,
+				E498D26B16F771D100D22636 /* GCDAsyncAction.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CedarAsyncSpecs/InTimeShouldSyntaxSpec.mm
+++ b/CedarAsyncSpecs/InTimeShouldSyntaxSpec.mm
@@ -1,5 +1,6 @@
 #import "CedarAsync.h"
 #import "AsyncAction.h"
+#import "GCDAsyncAction.h"
 #import "ExpectCallLength.h"
 #import "ExpectFailureWithMessage.h"
 
@@ -8,79 +9,115 @@ SPEC_BEGIN(InTimeSyntaxSpec)
 using namespace Cedar::Matchers;
 
 describe(@"in_time syntax", ^{
-    __block AsyncAction *action;
-
+    __block AsyncAction *timerAction;
+    __block GCDAsyncAction *gcdAction;
+    
     beforeEach(^{
-        action = [[[AsyncAction alloc] init] autorelease];
+        timerAction = [[[AsyncAction alloc] init] autorelease];
+        gcdAction = [[[GCDAsyncAction alloc] init] autorelease];
     });
-
-    describe(@"positive matching", ^{
-        context(@"when actual initially matches expected value", ^{
-            it(@"reports a pass", ^{
-                [action start];
-                expectShortCallLength(^{
-                    in_time(action.value) should equal(@"FROM");
-                });
-            });
+    
+    it(@"uses default timeout", ^{
+        Timing::current_timeout should equal(Timing::default_timeout);
+        Timing::current_timeout should be_greater_than(0);
+    });
+    
+    it(@"uses default poll", ^{
+        Timing::current_poll should equal(Timing::default_poll);
+        Timing::current_poll should be_less_than(Timing::current_timeout);
+        Timing::current_poll should be_greater_than(0);
+    });
+    
+    sharedExamplesFor(@"Asynchronous action", ^(NSDictionary *ctx) {
+        __block AsyncAction * action;
+        
+        beforeEach(^{
+            action = [ctx objectForKey:@"action"];
         });
-
-        context(@"when actual does not initially match expected value", ^{
-            context(@"when actual eventually matches expected value", ^{
+        
+        describe(@"positive matching", ^{
+            context(@"when actual initially matches expected value", ^{
                 it(@"reports a pass", ^{
                     [action start];
-                    expectLongCallLength(^{
-                        in_time(action.value) should equal(@"TO");
+                    expectShortCallLength(^{
+                        in_time(action.value) should equal(@"FROM");
                     });
                 });
             });
-
-            context(@"when actual does not eventually match expected value", ^{
-                it(@"reports a failure", ^{
-                    [action start];
-                    expectLongCallLength(^{
-                        expectFailureWithMessage(@"Expected <TO> to equal <OTHER>", ^{
-                            in_time(action.value) should equal(@"OTHER");
+            
+            context(@"when actual does not initially match expected value", ^{
+                context(@"when actual eventually matches expected value", ^{
+                        it(@"reports a pass", ^{
+                            [action start];
+                            expectLongCallLength(^{
+                                in_time(action.value) should equal(@"TO");
+                            });
+                        });
+                });
+                
+                context(@"when actual does not eventually match expected value", ^{
+                        it(@"reports a failure", ^{
+                            [action start];
+                            expectLongCallLength(^{
+                                expectFailureWithMessage(@"Expected <TO> to equal <OTHER>", ^{
+                                    in_time(action.value) should equal(@"OTHER");
+                                });
+                            });
+                        });
+                });
+            });
+        });
+        
+        describe(@"negative matching", ^{
+            context(@"when actual does not initially match expected value", ^{
+                    it(@"reports a pass", ^{
+                        [action start];
+                        expectShortCallLength(^{
+                            in_time(action.value) should_not equal(@"OTHER");
                         });
                     });
+            });
+            
+            context(@"when actual initially matches expected value", ^{
+                context(@"when actual eventually does not match expected value", ^{
+                        it(@"reports a pass", ^{
+                            [action start];
+                            expectLongCallLength(^{
+                                in_time(action.value) should_not equal(@"FROM");
+                            });
+                        });
+                });
+                
+                context(@"when actual eventually matches expected value", ^{
+                        it(@"reports a failure", ^{
+                            action.to = @"FROM";
+                            [action start];
+                            
+                            expectLongCallLength(^{
+                                expectFailureWithMessage(@"Expected <FROM> to not equal <FROM>", ^{
+                                    in_time(action.value) should_not equal(@"FROM");
+                                });
+                            });
+                        });
                 });
             });
         });
     });
-
-    describe(@"negative matching", ^{
-        context(@"when actual does not initially match expected value", ^{
-            it(@"reports a pass", ^{
-                [action start];
-                expectShortCallLength(^{
-                    in_time(action.value) should_not equal(@"OTHER");
-                });
-            });
+    
+    describe(@"NSTimer Async action", ^{
+        beforeEach(^{
+            [[SpecHelper specHelper].sharedExampleContext setObject:timerAction forKey:@"action"];
         });
-
-        context(@"when actual initially matches expected value", ^{
-            context(@"when actual eventually does not match expected value", ^{
-                it(@"reports a pass", ^{
-                    [action start];
-                    expectLongCallLength(^{
-                        in_time(action.value) should_not equal(@"FROM");
-                    });
-                });
-            });
-
-            context(@"when actual eventually matches expected value", ^{
-                it(@"reports a failure", ^{
-                    action.to = @"FROM";
-                    [action start];
-
-                    expectLongCallLength(^{
-                        expectFailureWithMessage(@"Expected <FROM> to not equal <FROM>", ^{
-                            in_time(action.value) should_not equal(@"FROM");
-                        });
-                    });
-                });
-            });
-        });
+        itShouldBehaveLike(@"Asynchronous action");
     });
+    
+    describe(@"GCD Async action", ^{
+        beforeEach(^{
+            [[SpecHelper specHelper].sharedExampleContext setObject:gcdAction forKey:@"action"];
+        });
+        itShouldBehaveLike(@"Asynchronous action");
+    });
+    
 });
 
 SPEC_END

--- a/CedarAsyncSpecs/Support/AsyncAction.h
+++ b/CedarAsyncSpecs/Support/AsyncAction.h
@@ -7,4 +7,5 @@
 
 - (void)start;
 - (int)valueCallCountAfterChange;
+- (void)end;
 @end

--- a/CedarAsyncSpecs/Support/GCDAsyncAction.h
+++ b/CedarAsyncSpecs/Support/GCDAsyncAction.h
@@ -1,0 +1,12 @@
+//
+//  GCDAsyncAction.h
+//  CedarAsync
+//
+//  Created by Paul Taykalo on 3/18/13.
+//
+//
+#import "AsyncAction.h"
+
+@interface GCDAsyncAction : AsyncAction
+
+@end

--- a/CedarAsyncSpecs/Support/GCDAsyncAction.mm
+++ b/CedarAsyncSpecs/Support/GCDAsyncAction.mm
@@ -1,0 +1,22 @@
+//
+//  GCDAsyncAction.m
+//  CedarAsync
+//
+//  Created by Paul Taykalo on 3/18/13.
+//
+//
+
+#import "GCDAsyncAction.h"
+
+@implementation GCDAsyncAction
+
+- (void)start {
+    self.value = self.from;
+    double delayInSeconds = self.delay;
+    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+    dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+        [self end];
+    });
+}
+
+@end

--- a/CedarAsyncSpecs/Support/HTTPClient.m
+++ b/CedarAsyncSpecs/Support/HTTPClient.m
@@ -29,6 +29,6 @@
 }
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection {
-    self.lastResponse = [[[NSString alloc] initWithData:self.responseData encoding:NSUTF8StringEncoding] autorelease];
+    self.lastResponse = [[[NSString alloc] initWithData:self.responseData encoding:NSASCIIStringEncoding] autorelease];
 }
 @end

--- a/Source/Timing.mm
+++ b/Source/Timing.mm
@@ -23,11 +23,15 @@ namespace CedarAsync {
             timeout:(NSTimeInterval)timeout {
 
     NSAssert(poll > 0, @"Poll must be > 0");
-
+    
     while (block(timeout <= 0)) {
         NSTimeInterval step = MIN(timeout, poll);
         timeout -= step;
 
+        // We need to add at any timer to current runloop in order to
+        // achieve correctly working runUntilDate method
+        [[NSRunLoop currentRunLoop] addTimer:[NSTimer timerWithTimeInterval:step invocation:nil repeats:NO] forMode:NSDefaultRunLoopMode];
+        
         NSDate *futureDate = [NSDate dateWithTimeIntervalSinceNow:step];
         [[NSRunLoop currentRunLoop] runUntilDate:futureDate];
     }


### PR DESCRIPTION
In case, if our Async operation isn't using NStimer, NSRunloop won't have active timers, and because of that it will return from `runUntilDate:` method immediately.
So this fix adds fake timer to runLoop, to make runUntilDate to work correctly.
# 

Tests updated for GCD Async action,
HTTP Client returns ASCII response instead of UTF-8 (default google page returns Non-valid UTF-8 response)
