### PR TITLE
Added podspec file for cocoapods

### DIFF
--- a/CedarAsync.podspec
+++ b/CedarAsync.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CedarAsync"
-  s.version      = "0.0.1"
+  s.version      = "0.0.2"
   s.summary      = "Asynchronous testing for Cedar (and others)."
   s.description  = "CedarAsync lets you use Cedar matchers to test asynchronous code."
   s.homepage     = "https://github.com/cppforlife/CedarAsync"


### PR DESCRIPTION
Hello! 
I've found that podspec for 'CedarAsync' is already exists on [CocoaPods specs](https://github.com/CocoaPods/Specs/blob/master/CedarAsync/0.0.1/CedarAsync.podspec). But it doesn't work with new version of [CocoaPods](http://cocoapods.org/) - 0.22.x. It's because of C++ compiler options.
So, I've made new podspec and it works fine! And it would be great to add it repo =)

So, if you merge this pull request then you can contribute CedarAsync podspec to [CocoaPods specs repo](https://github.com/CocoaPods/Specs). Or I can do it for you. Just ask me =)

Also, I don't know your email address, and you can update podspec file with it.
